### PR TITLE
comment totals are now represented on the main route

### DIFF
--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -1,13 +1,22 @@
 const Comment = require('../models/Comment')
+const Blog = require('../models/Blog')
 
 module.exports = {
     addComment: async (req, res) => {
         try {
+            //Create comment
             await Comment.create({
                 userName: req.user.userName, 
                 comment: req.body.comment, 
                 title: req.body.title
             })
+            //Find this specific blog then increment the totalComments property by one every time a new comment is added
+            await Blog.findOneAndUpdate(
+                {title: req.body.title},
+                {
+                    $inc: {totalComments: 1}
+                }
+            );
             //Redirecting 'back' takes us back to the previous page, acting as a refresh upon posting the comment
             res.redirect('back')
         } catch (error) {

--- a/routes/main.js
+++ b/routes/main.js
@@ -25,7 +25,7 @@ router.get('/:slug/article', async (req, res)=>{
     const commentTotal = await Comment.countDocuments({title: blog.title})
     const comments = await Comment.find({title: blog.title})
     if(blog == null) res.redirect('/')
-    res.render('index.ejs', {blog: blog, commentTotal: commentTotal, Allcomments: comments, username: req.user.userName, routeName: 'slug'})
+    res.render('index.ejs', {blog: blog, commentTotal: commentTotal, allComments: comments, username: req.user.userName, routeName: 'slug'})
 })
 
 // Grab the id of the file we would like to edit and then render our edit view

--- a/views/viewport/post.ejs
+++ b/views/viewport/post.ejs
@@ -30,7 +30,7 @@
             <input type="hidden" name="title" value="<%= blog.title %>">
             <button type="submit">Share</button>
         </form>
-        <% Allcomments.forEach((item)=> { %>
+        <% allComments.forEach((item)=> { %>
             <div class="blogComment">
                 <h6><%= item.userName %></h6>
                 <h6><%= item.date %></h6>


### PR DESCRIPTION
Closing #66 

Added a findOneAndUpdate to our comment controller that will update the blogs comment total in our db and be reflected on the main route. Video for reference.

Also fixed a previous typo in mainjs file in routes folder to read as camel case

https://user-images.githubusercontent.com/101610922/190035255-3067e53c-0184-48ff-9e71-d76deabc1e8c.mov

 to stay consistent (a mistake I previously overlooked).